### PR TITLE
Master

### DIFF
--- a/image-blp/examples/load.rs
+++ b/image-blp/examples/load.rs
@@ -1,10 +1,24 @@
 use ::image::DynamicImage;
-use image_blp::{convert::blp_to_image, parser::load_blp};
+use image_blp::{
+    convert::blp_to_image,
+    parser::{load_blp, load_blp_from_buf},
+};
 
 fn main() {
     let blp_filename = std::env::args().nth(1).unwrap_or("test.blp".to_owned());
     let output_filename = std::env::args().nth(2).unwrap_or("output.png".to_owned());
     let blp_file = load_blp(blp_filename).expect("loaded blp");
+    let image: DynamicImage = blp_to_image(&blp_file, 0).expect("converted");
+    image.save(output_filename).expect("saved");
+}
+
+#[test]
+fn test_from_buf() {
+    let blp_filename = std::env::args().nth(1).unwrap_or("test.blp".to_owned());
+    let output_filename = std::env::args().nth(2).unwrap_or("output.png".to_owned());
+    // load bytes
+    let blp_bytes = std::fs::read(blp_filename).expect("loaded blp");
+    let blp_file = load_blp_from_buf(blp_bytes).expect("loaded blp");
     let image: DynamicImage = blp_to_image(&blp_file, 0).expect("converted");
     image.save(output_filename).expect("saved");
 }

--- a/image-blp/src/parser/direct/blp2.rs
+++ b/image-blp/src/parser/direct/blp2.rs
@@ -107,15 +107,18 @@ pub fn parse_dxtn<'a>(
         let mut blocks_size = blocks_n * dxtn.block_size();
         trace!("Dxtn blocks count: {blocks_n}");
         trace!("Dxtn format: {dxtn:?}, block size: {}", dxtn.block_size());
-        trace!("Left size: {}, expected size: {}", image_bytes.len(), blocks_size);
+        trace!(
+            "Left size: {}, expected size: {}",
+            image_bytes.len(),
+            blocks_size
+        );
         if blocks_size > image_bytes.len() {
             warn!("Data is smaller than expected! Trying to read only whole number of blocks");
             let new_blocks_n = image_bytes.len() / dxtn.block_size();
             warn!("Reading {new_blocks_n} blocks");
             blocks_size = new_blocks_n * dxtn.block_size();
         }
-        let (_, content) =
-            context("dxtn blocks", count(le_u8, blocks_size))(image_bytes)?;
+        let (_, content) = context("dxtn blocks", count(le_u8, blocks_size))(image_bytes)?;
         images.push(DxtnImage { content });
         Ok(())
     };

--- a/image-blp/src/parser/mod.rs
+++ b/image-blp/src/parser/mod.rs
@@ -14,7 +14,7 @@ pub use error::{Error, LoadError};
 use header::parse_header;
 use jpeg::parse_jpeg_content;
 use nom::error::context;
-use std::{env, path::Path};
+use std::path::{Path, PathBuf};
 use types::Parser;
 
 /// Read BLP file from file system. If it BLP0 format, uses the mipmaps near the root file.
@@ -24,21 +24,20 @@ where
 {
     let input =
         std::fs::read(&path).map_err(|e| LoadError::FileSystem(path.as_ref().to_owned(), e))?;
-    load_blp_ex(path, input)
+    load_blp_ex(Some(path), input)
 }
 
 /// Read BLP file from buffer(Vec<u8>). If it BLP0 format, uses the mipmaps in the temp dir.
-pub fn load_blp_from_buf<Q>(buf: Q) -> Result<BlpImage, LoadError>
+pub fn load_blp_from_buf<R>(buf: R) -> Result<BlpImage, LoadError>
 where
-    Q: AsRef<Vec<u8>>,
+    R: AsRef<Vec<u8>>,
 {
     let input = buf;
-    let path = env::temp_dir().join("temp.blp");
-
+    let path: Option<PathBuf> = None;
     load_blp_ex(path, input)
 }
 
-fn load_blp_ex<Q, R>(path: Q, input: R) -> Result<BlpImage, LoadError>
+fn load_blp_ex<Q, R>(path: Option<Q>, input: R) -> Result<BlpImage, LoadError>
 where
     Q: AsRef<Path>,
     R: AsRef<Vec<u8>>,
@@ -46,16 +45,21 @@ where
     // We have to preload all mipmaps in memory as we are constrained with Nom 'a lifetime that
     // should be equal of lifetime of root input stream.
     let mut mipmaps = vec![];
-    for i in 0..16 {
-        let mipmap_path = make_mipmap_path(&path, i)
-            .ok_or_else(|| LoadError::InvalidFilename(path.as_ref().to_owned()))?;
-        if mipmap_path.is_file() {
-            let mipmap = std::fs::read(mipmap_path)
-                .map_err(|e| LoadError::FileSystem(path.as_ref().to_owned(), e))?;
-            mipmaps.push(mipmap);
-        } else {
-            break;
+    match path.as_ref() {
+        Some(path) => {
+            for i in 0..16 {
+                let mipmap_path = make_mipmap_path(&path, i)
+                    .ok_or_else(|| LoadError::InvalidFilename(path.as_ref().to_owned()))?;
+                if mipmap_path.is_file() {
+                    let mipmap = std::fs::read(mipmap_path)
+                        .map_err(|e| LoadError::FileSystem(path.as_ref().to_owned(), e))?;
+                    mipmaps.push(mipmap);
+                } else {
+                    break;
+                }
+            }
         }
+        None => {}
     }
 
     let image = match parse_blp_with_externals(&input.as_ref(), |i| preloaded_mipmaps(&mipmaps, i))

--- a/image-blp/src/parser/tests/blp2.rs
+++ b/image-blp/src/parser/tests/blp2.rs
@@ -310,8 +310,13 @@ fn test_achievement_metal_border_left() {
         width: 16,
         height: 512,
         mipmap_locator: MipmapLocator::Internal {
-            offsets: [1172, 9364, 11412, 11924, 11940, 11956, 11972, 11988, 12004, 12020, 0, 0, 0, 0, 0, 0],
-            sizes: [8192, 2048, 512, 16, 16, 16, 16, 16, 16, 16, 0, 0, 0, 0, 0, 0],
+            offsets: [
+                1172, 9364, 11412, 11924, 11940, 11956, 11972, 11988, 12004, 12020, 0, 0, 0, 0, 0,
+                0,
+            ],
+            sizes: [
+                8192, 2048, 512, 16, 16, 16, 16, 16, 16, 16, 0, 0, 0, 0, 0, 0,
+            ],
         },
     };
     blp2_test("UI-Achievement-MetalBorder-Left", blp_bytes, &header);


### PR DESCRIPTION
Add a new interface for loading blp files from a Vec<u8> buffer. 
This could be useful when using `mpq = "0.7"` to parse mpq files.